### PR TITLE
Fixed Standard Install and Removed Vanilla Musl

### DIFF
--- a/post_chroot.sh
+++ b/post_chroot.sh
@@ -53,12 +53,7 @@ case $line in
     echo "dev-vcs/git -gpg" >> /etc/portage/package.use
     emerge -uvNDq @world
     ;;
-  latest-stage3-amd64-musl-vanilla)
-    eselect profile set --force 30
-    echo "dev-vcs/git -gpg" >> /etc/portage/package.use
-    emerge -uvNDq @world
-    ;;
-  latest-stage3-amd64)
+  latest-stage3-amd64-openrc)
     emerge -uvNDq @world
     printf "big emerge complete\n"
     ;;

--- a/post_chroot.sh
+++ b/post_chroot.sh
@@ -6,9 +6,6 @@ cd deploygentoo-master
 scriptdir=$(pwd)
 cd ..
 sed -i '/^$/d' install_vars
-#rm -rf /mnt/gentoo/install_vars
-#cat /temp_f >> /mnt/gentoo/install_vars
-#rm -rf /mnt/gentoo/temp_f
 install_vars=install_vars
 
 install_vars_count="$(wc -w /install_vars)"

--- a/setup_gentoo.sh
+++ b/setup_gentoo.sh
@@ -46,7 +46,6 @@ while true; do
             part_3=("${disk_chk}3")
             part_4=("${disk_chk}4")
             mkfs.fat -F 32 $part_2
-            #mkfs.ext4 $part_2
             mkfs.ext4 $part_4
             mkswap $part_3
             swapon $part_3

--- a/setup_gentoo.sh
+++ b/setup_gentoo.sh
@@ -110,7 +110,7 @@ while true; do
 done
 
 printf "enter a number for the stage 3 you want to use\n"
-printf "0 = regular\n1 = regular hardened\n2 = hardened musl\n3 = vanilla musl\n>"
+printf "0 = regular\n1 = regular hardened\n2 = hardened musl\n>"
 read stage3select
 printf ${CYAN}"Enter the username for your NON ROOT user\n>"
 #There is a possibility this won't work since the handbook creates a user after rebooting and logging as root
@@ -162,9 +162,6 @@ case $stage3select in
     ;;
   2)
     GENTOO_TYPE=latest-stage3-amd64-musl-hardened
-    ;;
-  3)
-    GENTOO_TYPE=latest-stage3-amd64-musl-vanilla
     ;;
 esac
 

--- a/setup_gentoo.sh
+++ b/setup_gentoo.sh
@@ -155,7 +155,7 @@ rm -f network_devices
 
 case $stage3select in
   0)
-    GENTOO_TYPE=latest-stage3-amd64
+    GENTOO_TYPE=latest-stage3-amd64-openrc
     ;;
   1)
     GENTOO_TYPE=latest-stage3-amd64-hardened


### PR DESCRIPTION
* `vanilla musl` doesn't exist on the repo anymore (see [here](https://distfiles.gentoo.org/releases/amd64/autobuilds/)), so I removed it

* Added `-openrc` so that the standard installer works (tested on a VM). Perhaps add an option to choose systemd or openrc, although why one would chose the former I'm not sure.